### PR TITLE
feat: enhance pdf conversion with layout and metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@napi-rs/canvas": "^0.1.78",
         "express": "^5.1.0",
         "highlight.js": "^11.11.1",
         "markdown-it": "^14.1.0",
@@ -415,7 +416,6 @@
       "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.78.tgz",
       "integrity": "sha512-YaBHJvT+T1DoP16puvWM6w46Lq3VhwKIJ8th5m1iEJyGh7mibk5dT7flBvMQ1EH1LYmMzXJ+OUhu+8wQ9I6u7g==",
       "license": "MIT",
-      "optional": true,
       "workspaces": [
         "e2e/*"
       ],

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "license": "ISC",
   "type": "commonjs",
   "dependencies": {
+    "@napi-rs/canvas": "^0.1.78",
     "express": "^5.1.0",
     "highlight.js": "^11.11.1",
     "markdown-it": "^14.1.0",


### PR DESCRIPTION
## Summary
- preserve PDF formatting by rendering pages to images and overlaying positioned text
- embed page styles and collect document metadata
- include metadata in convert response for downstream features

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b47d64e61883209738510005360cd9